### PR TITLE
Add SQLite-backed task persistence and cross-worker test

### DIFF
--- a/task_repository.py
+++ b/task_repository.py
@@ -1,0 +1,123 @@
+"""SQLite-backed persistence for background task records."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class TaskRecord:
+    """Internal representation of a long running task."""
+
+    id: str
+    status: str
+    created_at: datetime
+    config_payload: Dict[str, Any]
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the task into a JSON-ready structure."""
+
+        return {
+            "id": self.id,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
+            "config": self.config_payload,
+            "error": self.error,
+            "metadata": self.metadata,
+            "result": self.result,
+        }
+
+
+class TaskRepository:
+    """SQLite backed persistence for :class:`TaskRecord` objects."""
+
+    def __init__(self, database: str) -> None:
+        self.database = database
+        db_path = Path(database)
+        if db_path.parent and not db_path.parent.exists():
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    config TEXT NOT NULL,
+                    result TEXT,
+                    error TEXT,
+                    metadata TEXT NOT NULL
+                )
+                """
+            )
+
+    def create_task(self, record: TaskRecord) -> None:
+        payload = (
+            record.id,
+            record.status,
+            record.created_at.isoformat(),
+            json.dumps(record.config_payload),
+            json.dumps(record.result) if record.result is not None else None,
+            record.error,
+            json.dumps(record.metadata or {}),
+        )
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO tasks (id, status, created_at, config, result, error, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                payload,
+            )
+
+    def update_status(self, task_id: str, status: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?",
+                (status, task_id),
+            )
+
+    def update_result(self, task_id: str, result: Dict[str, Any]) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "UPDATE tasks SET status = ?, result = ?, error = NULL WHERE id = ?",
+                ("finished", json.dumps(result), task_id),
+            )
+
+    def update_error(self, task_id: str, message: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "UPDATE tasks SET status = ?, error = ?, result = NULL WHERE id = ?",
+                ("failed", message, task_id),
+            )
+
+    def get(self, task_id: str) -> Optional[TaskRecord]:
+        with self._connect() as connection:
+            cursor = connection.execute("SELECT * FROM tasks WHERE id = ?", (task_id,))
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return TaskRecord(
+            id=row["id"],
+            status=row["status"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            config_payload=json.loads(row["config"]),
+            result=json.loads(row["result"]) if row["result"] else None,
+            error=row["error"],
+            metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+        )

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,0 +1,52 @@
+"""Tests for the TaskManager persistence layer."""
+from __future__ import annotations
+
+import time
+from threading import Event
+
+from task_repository import TaskRepository
+from webapp import TaskManager
+
+
+class DummyResult:
+    """Minimal stand-in for :class:`agent_core.AgentResult`."""
+
+    def __init__(self, report: str) -> None:
+        self.report = report
+
+    def to_dict(self) -> dict:
+        return {"report": self.report}
+
+
+def test_task_persistence_across_managers(tmp_path) -> None:
+    """Two managers should see the same task record via the repository."""
+
+    database_path = tmp_path / "tasks.db"
+    repository = TaskRepository(str(database_path))
+    manager_a = TaskManager(repository)
+    manager_b = TaskManager(repository)
+
+    completed = Event()
+
+    def _run() -> DummyResult:
+        completed.set()
+        return DummyResult("Report from worker")
+
+    record = manager_a.submit({"foo": "bar"}, _run)
+    assert completed.wait(timeout=5), "Background task did not complete in time"
+
+    retrieved = None
+    for _ in range(50):
+        retrieved = manager_b.get(record.id)
+        if retrieved and retrieved.status == "finished":
+            break
+        time.sleep(0.1)
+
+    assert retrieved is not None
+    assert retrieved.status == "finished"
+    payload = retrieved.to_dict()
+    assert payload["config"] == {"foo": "bar"}
+    assert payload["result"]["report"] == "Report from worker"
+
+    manager_a.executor.shutdown(wait=True)
+    manager_b.executor.shutdown(wait=True)


### PR DESCRIPTION
## Summary
- add a SQLite-backed repository and TaskRecord dataclass to persist background task state
- refactor the Flask TaskManager to store and read task updates via the shared repository and update Telegram notifications for dict-based results
- add a regression test that verifies two TaskManager instances can read the same task via the shared store

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae28038188331a3e69361fdc54ff9