### PR TITLE
Fix Telegram token retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Hybrides Agentensystem zur Recherche von Pauschalreisen mit Web-Oberfläche, asynchronem Flask-Backend
 und Telegram-Bot-Steuerung. Das Projekt besteht aus vier entkoppelten Hauptkomponenten:
 
+> **Hinweis:** Der Telegram-Bot-Token wird nicht im Repository gespeichert und muss vor dem Start über die
+> Umgebungsvariable `TELEGRAM_BOT_TOKEN` gesetzt werden.
+
 1. **Frontend (Web-UI)** – HTML-Formular zur Eingabe aller Reiseparameter.
 2. **Backend (Flask API & Orchestrator)** – nimmt Anfragen der UI und des Bots entgegen und verwaltet
 die Hintergrundtasks.

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
 BACKEND_URL: Final[str] = os.getenv("TRAVEL_AGENT_BACKEND_URL", "http://localhost:5000")
-BOT_TOKEN: Final[str | None] = os.getenv(8435342547:AAEzVNMINrH9AHYhUitC4Dbbvr6iyXyAMLw")
+BOT_TOKEN: Final[str | None] = os.getenv("TELEGRAM_BOT_TOKEN")
 
 
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- fix the Telegram bot token retrieval to read from the TELEGRAM_BOT_TOKEN environment variable
- document in the README that the token must be supplied via the TELEGRAM_BOT_TOKEN environment variable

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68caed5148f0833192ca41c6a4d1cfdd