### PR TITLE
Add portal-specific Playwright scraping

### DIFF
--- a/agent_core/scraper.py
+++ b/agent_core/scraper.py
@@ -5,8 +5,8 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Set
-from urllib.parse import quote_plus, urlparse
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Set
+from urllib.parse import quote_plus, urljoin, urlparse
 
 try:  # pragma: no cover - optional dependency during development
     from playwright.async_api import Browser, Page, async_playwright  # type: ignore
@@ -23,6 +23,102 @@ _STAR_PATTERN = re.compile(r"(\d(?:[.,]\d)?)\s*(?:sterne|stars)", re.IGNORECASE)
 _RECOMMENDATION_PATTERN = re.compile(
     r"(\d{1,3})\s?%[^%]*(?:weiterempfehlung|recommended|bewertung)", re.IGNORECASE
 )
+
+
+def _parse_price_from_text(text: str) -> Optional[float]:
+    """Extract a float price from a loosely formatted string."""
+
+    match = _PRICE_PATTERN.search(text)
+    if not match:
+        return None
+    try:
+        numeric = match.group(1).replace(".", "").replace(",", ".")
+        return float(numeric)
+    except ValueError:
+        return None
+
+
+async def _try_fill_field(page: Page, selectors: Iterable[str], value: str) -> None:
+    """Attempt to fill the first selector that works on the current page."""
+
+    if not value:
+        return
+    for selector in selectors:
+        try:
+            await page.fill(selector, value)
+            return
+        except Exception:
+            try:
+                locator = page.locator(selector)
+            except Exception:
+                locator = None
+            if locator is None:
+                continue
+            try:
+                await locator.fill(value)
+                return
+            except Exception:
+                continue
+
+
+async def _try_select_option(page: Page, selectors: Iterable[str], value: str) -> bool:
+    """Attempt to select an option; return True on success."""
+
+    if not value:
+        return False
+    for selector in selectors:
+        try:
+            await page.select_option(selector, value)
+            return True
+        except Exception:
+            continue
+    return False
+
+
+async def _extract_text(handle: Any, selectors: Iterable[str]) -> Optional[str]:
+    """Return the first non-empty text for the given selectors."""
+
+    for selector in selectors:
+        try:
+            element = await handle.query_selector(selector)
+        except Exception:
+            continue
+        if element is None:
+            continue
+        text: Optional[str] = None
+        try:
+            text = await element.inner_text()
+        except Exception:
+            try:
+                text = await element.text_content()
+            except Exception:
+                text = None
+        if text:
+            stripped = text.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+async def _extract_attribute(
+    handle: Any, selectors: Iterable[str], attribute: str
+) -> Optional[str]:
+    """Fetch an attribute from the first matching selector."""
+
+    for selector in selectors:
+        try:
+            element = await handle.query_selector(selector)
+        except Exception:
+            continue
+        if element is None:
+            continue
+        try:
+            value = await element.get_attribute(attribute)
+        except Exception:
+            value = None
+        if value:
+            return value
+    return None
 
 @dataclass
 class RawOffer:
@@ -88,13 +184,7 @@ async def _extract_duckduckgo_results(
             snippet_el = await card.query_selector("div.result__snippet")
         snippet = (await snippet_el.inner_text()).strip() if snippet_el else ""
 
-        price = None
-        price_match = _PRICE_PATTERN.search(snippet)
-        if price_match:
-            try:
-                price = float(price_match.group(1).replace(".", "").replace(",", "."))
-            except ValueError:
-                price = None
+        price = _parse_price_from_text(snippet)
 
         star_rating = None
         star_match = _STAR_PATTERN.search(snippet)
@@ -138,6 +228,353 @@ async def _extract_duckduckgo_results(
     return offers
 
 
+async def _search_holidaycheck(
+    page: Page, config: AgentConfig, destination: str, max_results: int = 5
+) -> List[RawOffer]:
+    """Search holidaycheck.de directly and extract structured offers."""
+
+    base_url = "https://www.holidaycheck.de/"
+
+    await page.goto(base_url, wait_until="domcontentloaded")
+    await _dismiss_common_banners(page)
+
+    await _try_fill_field(
+        page,
+        [
+            "input[name='destination']",
+            "input[data-testid='destination-input']",
+            "input[aria-label='Reiseziel']",
+        ],
+        destination,
+    )
+
+    if config.departure_date:
+        await _try_fill_field(
+            page,
+            [
+                "input[name='departureDate']",
+                "input[data-testid='date-range-start']",
+                "input[name='startDate']",
+            ],
+            config.departure_date.isoformat(),
+        )
+    if config.return_date:
+        await _try_fill_field(
+            page,
+            [
+                "input[name='returnDate']",
+                "input[data-testid='date-range-end']",
+                "input[name='endDate']",
+            ],
+            config.return_date.isoformat(),
+        )
+
+    travellers_value = str(config.travellers or 2)
+    if not await _try_select_option(
+        page,
+        [
+            "select[name='travellers']",
+            "select[name='guests']",
+            "select[data-testid='guest-select']",
+        ],
+        travellers_value,
+    ):
+        await _try_fill_field(
+            page,
+            ["input[name='travellers']", "input[name='guests']"],
+            travellers_value,
+        )
+
+    if config.budget is not None:
+        await _try_fill_field(
+            page,
+            ["input[name='budget']", "input[data-testid='price-budget']"],
+            f"{int(config.budget)}",
+        )
+
+    for selector in [
+        "button[type='submit']",
+        "button[data-testid='search-button']",
+        "button:has-text('Angebote anzeigen')",
+    ]:
+        try:
+            await page.click(selector)
+            break
+        except Exception:
+            continue
+
+    try:
+        await page.wait_for_load_state("networkidle")
+    except Exception:
+        pass
+    await _dismiss_common_banners(page)
+
+    cards = await page.query_selector_all("[data-testid='offer-card']")
+    if not cards:
+        cards = await page.query_selector_all("article[data-testid='hc-result-card']")
+    if not cards:
+        cards = await page.query_selector_all("article")
+
+    offers: List[RawOffer] = []
+    for card in cards:
+        title = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-title']",
+                ".offer-title",
+                ".hotel-name",
+                "header h3",
+            ],
+        )
+        if not title:
+            continue
+
+        href = await _extract_attribute(card, ["a[data-testid='offer-link']", "a[href]"], "href")
+        url = urljoin(base_url, href) if href else base_url
+
+        price_text = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-price']",
+                ".offer-price",
+                ".price",
+                "[data-testid='offer-card'] [data-testid='price']",
+            ],
+        )
+        price = _parse_price_from_text(price_text) if price_text else None
+
+        board = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-board']",
+                ".board",
+                "[data-testid='catering']",
+            ],
+        )
+        duration = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-duration']",
+                ".duration",
+                "[data-testid='stay-length']",
+            ],
+        )
+        rating_text = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-rating']",
+                ".rating",
+                "[data-testid='recommendation']",
+            ],
+        )
+
+        metadata: Dict[str, Any] = {
+            "destination": destination,
+            "source": "holidaycheck.de",
+            "travellers": config.travellers,
+        }
+        if config.departure_date:
+            metadata["departure_date"] = config.departure_date.isoformat()
+        if config.return_date:
+            metadata["return_date"] = config.return_date.isoformat()
+        if config.budget is not None:
+            metadata["budget"] = config.budget
+        if board:
+            metadata["board"] = board
+        if duration:
+            metadata["duration"] = duration
+
+        if rating_text:
+            star_match = _STAR_PATTERN.search(rating_text)
+            if star_match:
+                try:
+                    metadata["star_rating"] = float(
+                        star_match.group(1).replace(",", ".")
+                    )
+                except ValueError:
+                    pass
+            recommendation_match = _RECOMMENDATION_PATTERN.search(rating_text)
+            if recommendation_match:
+                try:
+                    metadata["recommendation_score"] = float(
+                        recommendation_match.group(1)
+                    )
+                except ValueError:
+                    pass
+
+        offers.append(
+            RawOffer(
+                provider="holidaycheck.de",
+                title=title,
+                price=price,
+                url=url,
+                metadata=metadata,
+            )
+        )
+        if len(offers) >= max_results:
+            break
+
+    return offers
+
+
+async def _search_tui(
+    page: Page, config: AgentConfig, destination: str, max_results: int = 5
+) -> List[RawOffer]:
+    """Search tui.com for a given destination."""
+
+    base_url = "https://www.tui.com/"
+    search_url = urljoin(base_url, "pauschalreisen/")
+
+    await page.goto(search_url, wait_until="domcontentloaded")
+    await _dismiss_common_banners(page)
+
+    await _try_fill_field(
+        page,
+        [
+            "input[name='q']",
+            "input[data-testid='search-input']",
+            "input[placeholder*='Wohin']",
+        ],
+        destination,
+    )
+
+    if config.departure_date:
+        await _try_fill_field(
+            page,
+            ["input[name='departureDate']", "input[data-testid='date-departure']"],
+            config.departure_date.isoformat(),
+        )
+    if config.return_date:
+        await _try_fill_field(
+            page,
+            ["input[name='returnDate']", "input[data-testid='date-return']"],
+            config.return_date.isoformat(),
+        )
+
+    travellers_value = str(config.travellers or 2)
+    if not await _try_select_option(
+        page,
+        ["select[name='travellers']", "select[data-testid='travellers-select']"],
+        travellers_value,
+    ):
+        await _try_fill_field(page, ["input[name='travellers']"], travellers_value)
+
+    if config.budget is not None:
+        await _try_fill_field(
+            page,
+            ["input[name='maxPrice']", "input[data-testid='price-to']"],
+            f"{int(config.budget)}",
+        )
+
+    for selector in [
+        "button[type='submit']",
+        "button[data-testid='search-button']",
+        "button:has-text('Angebote finden')",
+    ]:
+        try:
+            await page.click(selector)
+            break
+        except Exception:
+            continue
+
+    try:
+        await page.wait_for_load_state("networkidle")
+    except Exception:
+        pass
+    await _dismiss_common_banners(page)
+
+    cards = await page.query_selector_all("[data-testid='offer-card']")
+    if not cards:
+        cards = await page.query_selector_all("article[data-testid='result-card']")
+    if not cards:
+        cards = await page.query_selector_all("article")
+
+    offers: List[RawOffer] = []
+    for card in cards:
+        title = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-title']",
+                ".offer-title",
+                ".product-tile__title",
+                "header h3",
+            ],
+        )
+        if not title:
+            continue
+
+        href = await _extract_attribute(
+            card,
+            ["a[data-testid='offer-link']", "a[href]"],
+            "href",
+        )
+        url = urljoin(base_url, href) if href else base_url
+
+        price_text = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-price']",
+                ".offer-price",
+                ".price",
+                "[data-testid='product-price']",
+            ],
+        )
+        price = _parse_price_from_text(price_text) if price_text else None
+
+        board = await _extract_text(
+            card,
+            ["[data-testid='offer-board']", ".board", "[data-testid='product-board']"],
+        )
+        duration = await _extract_text(
+            card,
+            [
+                "[data-testid='offer-duration']",
+                ".duration",
+                "[data-testid='product-duration']",
+            ],
+        )
+
+        metadata: Dict[str, Any] = {
+            "destination": destination,
+            "source": "tui.com",
+            "travellers": config.travellers,
+        }
+        if config.departure_date:
+            metadata["departure_date"] = config.departure_date.isoformat()
+        if config.return_date:
+            metadata["return_date"] = config.return_date.isoformat()
+        if config.budget is not None:
+            metadata["budget"] = config.budget
+        if board:
+            metadata["board"] = board
+        if duration:
+            metadata["duration"] = duration
+
+        offers.append(
+            RawOffer(
+                provider="tui.com",
+                title=title,
+                price=price,
+                url=url,
+                metadata=metadata,
+            )
+        )
+        if len(offers) >= max_results:
+            break
+
+    return offers
+
+
+_PORTAL_SEARCH_HANDLERS: Dict[
+    str, Callable[[Page, AgentConfig, str], Awaitable[List[RawOffer]]]
+] = {
+    "holidaycheck.de": _search_holidaycheck,
+    "www.holidaycheck.de": _search_holidaycheck,
+    "tui.com": _search_tui,
+    "www.tui.com": _search_tui,
+}
+
+
 async def _scrape_with_playwright(config: AgentConfig) -> Iterable[RawOffer]:
     """Collect offers by driving a headless browser via Playwright."""
 
@@ -160,14 +597,21 @@ async def _scrape_with_playwright(config: AgentConfig) -> Iterable[RawOffer]:
                 continue
             normalised_source = re.sub(r"^https?://", "", source.strip().lower())
             normalised_source = normalised_source.rstrip("/")
+            handler = _PORTAL_SEARCH_HANDLERS.get(normalised_source)
             for destination in destinations:
                 try:
-                    destination_offers = await _extract_duckduckgo_results(
-                        page, destination, site=normalised_source
-                    )
+                    if handler is not None:
+                        destination_offers = await handler(page, config, destination)
+                    else:
+                        destination_offers = await _extract_duckduckgo_results(
+                            page, destination, site=normalised_source
+                        )
                 except Exception as exc:  # pragma: no cover - network dependent
                     LOGGER.warning(
-                        "Playwright scraping failed for %s@%s: %s", normalised_source, destination, exc
+                        "Playwright scraping failed for %s@%s: %s",
+                        normalised_source,
+                        destination,
+                        exc,
                     )
                     continue
                 for offer in destination_offers:

--- a/tests/test_scraper_portals.py
+++ b/tests/test_scraper_portals.py
@@ -1,0 +1,157 @@
+"""Tests for portal specific Playwright scrapers."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import pytest
+
+from agent_core.config import AgentConfig
+from agent_core.scraper import RawOffer, _search_holidaycheck
+
+
+class _StubLocator:
+    """Minimal locator stub that records click/fill invocations."""
+
+    def __init__(self) -> None:
+        self.clicks: List[int] = []
+        self.fill_values: List[str] = []
+
+    @property
+    def first(self) -> "_StubLocator":
+        return self
+
+    async def click(self, timeout: int | None = None) -> None:
+        self.clicks.append(timeout or 0)
+
+    async def fill(self, value: str) -> None:
+        self.fill_values.append(value)
+
+
+class _StubElement:
+    def __init__(self, text: str = "", attributes: Optional[Dict[str, str]] = None) -> None:
+        self._text = text
+        self._attributes = attributes or {}
+
+    async def inner_text(self) -> str:
+        return self._text
+
+    async def text_content(self) -> str:
+        return self._text
+
+    async def get_attribute(self, name: str) -> Optional[str]:
+        return self._attributes.get(name)
+
+
+class _StubCard:
+    def __init__(
+        self,
+        title: str,
+        href: str,
+        price_text: str,
+        board: str = "",
+        duration: str = "",
+        rating: str = "",
+    ) -> None:
+        self._elements: Dict[str, _StubElement] = {
+            "[data-testid='offer-title']": _StubElement(title),
+            ".offer-title": _StubElement(title),
+            "header h3": _StubElement(title),
+            "a[data-testid='offer-link']": _StubElement("", {"href": href}),
+            "a[href]": _StubElement("", {"href": href}),
+            "[data-testid='offer-price']": _StubElement(price_text),
+            ".offer-price": _StubElement(price_text),
+        }
+        if board:
+            self._elements["[data-testid='offer-board']"] = _StubElement(board)
+        if duration:
+            self._elements["[data-testid='offer-duration']"] = _StubElement(duration)
+        if rating:
+            self._elements["[data-testid='offer-rating']"] = _StubElement(rating)
+
+    async def query_selector(self, selector: str) -> Optional[_StubElement]:
+        return self._elements.get(selector)
+
+
+class _StubPage:
+    """Imitates the small Playwright API surface used in tests."""
+
+    def __init__(self, cards: Optional[List[_StubCard]] = None) -> None:
+        self.cards = cards or []
+        self.goto_calls: List[tuple[str, Optional[str]]] = []
+        self.filled: Dict[str, str] = {}
+        self.selected: Dict[str, str] = {}
+        self.clicks: List[str] = []
+        self.load_states: List[str] = []
+
+    async def goto(self, url: str, wait_until: Optional[str] = None) -> None:
+        self.goto_calls.append((url, wait_until))
+
+    async def fill(self, selector: str, value: str) -> None:
+        self.filled[selector] = value
+
+    def locator(self, selector: str) -> _StubLocator:
+        return _StubLocator()
+
+    async def select_option(self, selector: str, value: str) -> None:
+        self.selected[selector] = value
+
+    async def click(self, selector: str) -> None:
+        self.clicks.append(selector)
+
+    async def wait_for_load_state(self, state: str) -> None:
+        self.load_states.append(state)
+
+    async def query_selector_all(self, selector: str) -> List[_StubCard]:
+        if selector in {
+            "[data-testid='offer-card']",
+            "article[data-testid='hc-result-card']",
+            "article",
+        }:
+            return self.cards
+        return []
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Restrict anyio tests to the asyncio backend for deterministic behaviour."""
+
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_search_holidaycheck_returns_raw_offers() -> None:
+    """HolidayCheck scraping should transform cards into RawOffer objects."""
+
+    page = _StubPage(
+        cards=[
+            _StubCard(
+                title="Hotel Mallorca",
+                href="/offers/1",
+                price_text="ab 999 €",
+                board="Halbpension",
+                duration="7 Nächte",
+                rating="95 % Weiterempfehlung",
+            )
+        ]
+    )
+    config = AgentConfig(destinations=["Mallorca"], travellers=2, budget=1200.0)
+
+    offers = await _search_holidaycheck(page, config, "Mallorca")
+
+    assert offers, "expected at least one RawOffer"
+
+    offer = offers[0]
+    assert isinstance(offer, RawOffer)
+    assert offer.provider == "holidaycheck.de"
+    assert offer.title == "Hotel Mallorca"
+    assert offer.url == "https://www.holidaycheck.de/offers/1"
+    assert offer.price == 999.0
+    assert offer.metadata["destination"] == "Mallorca"
+    assert offer.metadata["travellers"] == 2
+    assert offer.metadata["board"] == "Halbpension"
+    assert offer.metadata.get("recommendation_score") == 95.0
+
+    # The stubbed inputs should have been filled with search parameters.
+    assert page.filled["input[name='destination']"] == "Mallorca"
+    assert page.selected.get("select[name='travellers']") == "2"


### PR DESCRIPTION
## Summary
- add helper utilities for filling portal forms and parsing offer cards
- implement HolidayCheck and TUI scraping handlers and integrate them into the Playwright workflow
- cover the new HolidayCheck handler with an async test using a Playwright page stub

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb01ed2b208331a668fcee989abde1