### PR TITLE
Parse nights from portal durations

### DIFF
--- a/agent_core/scraper.py
+++ b/agent_core/scraper.py
@@ -23,6 +23,9 @@ _STAR_PATTERN = re.compile(r"(\d(?:[.,]\d)?)\s*(?:sterne|stars)", re.IGNORECASE)
 _RECOMMENDATION_PATTERN = re.compile(
     r"(\d{1,3})\s?%[^%]*(?:weiterempfehlung|recommended|bewertung)", re.IGNORECASE
 )
+_NIGHTS_PATTERN = re.compile(
+    r"(\d+)\s*(?:nächte?|nacht|naechte?|tage?|tag|days?|day)", re.IGNORECASE
+)
 
 
 def _parse_price_from_text(text: str) -> Optional[float]:
@@ -34,6 +37,21 @@ def _parse_price_from_text(text: str) -> Optional[float]:
     try:
         numeric = match.group(1).replace(".", "").replace(",", ".")
         return float(numeric)
+    except ValueError:
+        return None
+
+
+def _parse_nights_from_text(text: str) -> Optional[int]:
+    """Extract the number of nights from a duration string."""
+
+    if not text:
+        return None
+
+    match = _NIGHTS_PATTERN.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
     except ValueError:
         return None
 
@@ -359,6 +377,7 @@ async def _search_holidaycheck(
                 "[data-testid='stay-length']",
             ],
         )
+        nights = _parse_nights_from_text(duration) if duration else None
         rating_text = await _extract_text(
             card,
             [
@@ -383,6 +402,8 @@ async def _search_holidaycheck(
             metadata["board"] = board
         if duration:
             metadata["duration"] = duration
+        if nights is not None:
+            metadata["nights"] = nights
 
         if rating_text:
             star_match = _STAR_PATTERN.search(rating_text)
@@ -533,6 +554,7 @@ async def _search_tui(
                 "[data-testid='product-duration']",
             ],
         )
+        nights = _parse_nights_from_text(duration) if duration else None
 
         metadata: Dict[str, Any] = {
             "destination": destination,
@@ -549,6 +571,8 @@ async def _search_tui(
             metadata["board"] = board
         if duration:
             metadata["duration"] = duration
+        if nights is not None:
+            metadata["nights"] = nights
 
         offers.append(
             RawOffer(

--- a/tests/test_scraper_portals.py
+++ b/tests/test_scraper_portals.py
@@ -7,7 +7,8 @@ from typing import Dict, List, Optional
 import pytest
 
 from agent_core.config import AgentConfig
-from agent_core.scraper import RawOffer, _search_holidaycheck
+from agent_core.processor import prepare_offers
+from agent_core.scraper import RawOffer, _search_holidaycheck, _search_tui
 
 
 class _StubLocator:
@@ -53,21 +54,37 @@ class _StubCard:
         duration: str = "",
         rating: str = "",
     ) -> None:
+        title_element = _StubElement(title)
+        price_element = _StubElement(price_text)
         self._elements: Dict[str, _StubElement] = {
-            "[data-testid='offer-title']": _StubElement(title),
-            ".offer-title": _StubElement(title),
-            "header h3": _StubElement(title),
+            "[data-testid='offer-title']": title_element,
+            ".offer-title": title_element,
+            ".hotel-name": title_element,
+            "header h3": title_element,
             "a[data-testid='offer-link']": _StubElement("", {"href": href}),
             "a[href]": _StubElement("", {"href": href}),
-            "[data-testid='offer-price']": _StubElement(price_text),
-            ".offer-price": _StubElement(price_text),
+            "[data-testid='offer-price']": price_element,
+            ".offer-price": price_element,
+            ".price": price_element,
+            "[data-testid='product-price']": price_element,
         }
         if board:
-            self._elements["[data-testid='offer-board']"] = _StubElement(board)
+            board_element = _StubElement(board)
+            self._elements["[data-testid='offer-board']"] = board_element
+            self._elements[".board"] = board_element
+            self._elements["[data-testid='catering']"] = board_element
+            self._elements["[data-testid='product-board']"] = board_element
         if duration:
-            self._elements["[data-testid='offer-duration']"] = _StubElement(duration)
+            duration_element = _StubElement(duration)
+            self._elements["[data-testid='offer-duration']"] = duration_element
+            self._elements[".duration"] = duration_element
+            self._elements["[data-testid='stay-length']"] = duration_element
+            self._elements["[data-testid='product-duration']"] = duration_element
         if rating:
-            self._elements["[data-testid='offer-rating']"] = _StubElement(rating)
+            rating_element = _StubElement(rating)
+            self._elements["[data-testid='offer-rating']"] = rating_element
+            self._elements[".rating"] = rating_element
+            self._elements["[data-testid='recommendation']"] = rating_element
 
     async def query_selector(self, selector: str) -> Optional[_StubElement]:
         return self._elements.get(selector)
@@ -106,6 +123,7 @@ class _StubPage:
         if selector in {
             "[data-testid='offer-card']",
             "article[data-testid='hc-result-card']",
+            "article[data-testid='result-card']",
             "article",
         }:
             return self.cards
@@ -151,7 +169,43 @@ async def test_search_holidaycheck_returns_raw_offers() -> None:
     assert offer.metadata["travellers"] == 2
     assert offer.metadata["board"] == "Halbpension"
     assert offer.metadata.get("recommendation_score") == 95.0
+    assert offer.metadata["duration"] == "7 Nächte"
+    assert offer.metadata["nights"] == 7
 
     # The stubbed inputs should have been filled with search parameters.
     assert page.filled["input[name='destination']"] == "Mallorca"
     assert page.selected.get("select[name='travellers']") == "2"
+
+    processed_offers = prepare_offers(offers, config)
+    assert processed_offers and processed_offers[0].nights == 7
+
+
+@pytest.mark.anyio
+async def test_search_tui_extracts_nights_and_prepares_offers() -> None:
+    """TUI scraping should preserve duration metadata and parsed nights."""
+
+    page = _StubPage(
+        cards=[
+            _StubCard(
+                title="Resort Kreta",
+                href="/angebote/kreta",
+                price_text="1299 €",
+                board="All Inclusive",
+                duration="10 Tage",
+            )
+        ]
+    )
+    config = AgentConfig(destinations=["Kreta"], travellers=2)
+
+    offers = await _search_tui(page, config, "Kreta")
+
+    assert offers, "expected at least one RawOffer"
+
+    offer = offers[0]
+    assert isinstance(offer, RawOffer)
+    assert offer.provider == "tui.com"
+    assert offer.metadata["duration"] == "10 Tage"
+    assert offer.metadata["nights"] == 10
+
+    processed_offers = prepare_offers(offers, config)
+    assert processed_offers and processed_offers[0].nights == 10


### PR DESCRIPTION
## Summary
- add a shared helper to extract night counts from portal duration strings
- populate the parsed night counts in HolidayCheck and TUI offer metadata
- extend portal scraper tests to assert the metadata and processor output carry the parsed nights

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb05c32c608331862473b8c988aea1