### PR TITLE
Add warning propagation for mock travel offers

### DIFF
--- a/agent_core/reporter.py
+++ b/agent_core/reporter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import date
 import math
-from typing import Iterable, List
+from typing import Iterable, List, Sequence
 
 from .config import AgentConfig
 from .processor import ProcessedOffer, summarise_offers
@@ -68,18 +68,29 @@ def generate_offer_table(offers: Iterable[ProcessedOffer]) -> str:
     return "\n".join(rows)
 
 
-def build_report(config: AgentConfig, offers: List[ProcessedOffer]) -> str:
+def build_report(
+    config: AgentConfig, offers: List[ProcessedOffer], warnings: Sequence[str] | None = None
+) -> str:
     """Create a text report summarising the results."""
 
     summary = summarise_offers(offers)
+    warning_messages = [message.strip() for message in (warnings or []) if message]
     lines: List[str] = [
         "Reise-Report",
         "============",
-        "",
-        f"Ziele: {', '.join(config.destinations)}",
+    ]
+    if warning_messages:
+        lines.append("")
+        lines.extend(f"WARNUNG: {message}" for message in warning_messages)
+
+    lines.extend(
+        [
+            "",
+            f"Ziele: {', '.join(config.destinations)}",
         f"Zeitraum: {_format_date(config.departure_date)} – {_format_date(config.return_date)}",
         f"Reisende: {config.travellers}",
-    ]
+        ]
+    )
     if config.budget:
         lines.append(f"Budget: {config.budget:.0f} €")
     if config.board_types:

--- a/agent_core/scraper.py
+++ b/agent_core/scraper.py
@@ -130,6 +130,17 @@ class RawOffer:
     url: str
     metadata: Dict[str, Any]
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the raw offer to a JSON-compatible structure."""
+
+        return {
+            "provider": self.provider,
+            "title": self.title,
+            "price": self.price,
+            "url": self.url,
+            "metadata": dict(self.metadata),
+        }
+
 
 async def _dismiss_common_banners(page: Page) -> None:
     """Attempt to dismiss cookie/consent banners that block results."""
@@ -665,15 +676,15 @@ def _fallback_mock_offers(config: AgentConfig, reason: str | None = None) -> Lis
     LOGGER.debug("Falling back to mock offers: %s", reason or "no details")
 
     mocked_prices = [749.0, 899.0, 1020.0]
-    providers = ["HolidayCheck", "TUI", "Booking.com"]
     mocked_star_ratings = [4.0, 4.5, 3.5]
     mocked_recommendations = [88.0, 92.0, 85.0]
     offers: List[RawOffer] = []
     for idx, destination in enumerate(config.destinations or ["Unbekannt"]):
         price = mocked_prices[idx % len(mocked_prices)]
+        mock_reason = reason or "mock"
         offers.append(
             RawOffer(
-                provider=providers[idx % len(providers)],
+                provider="Mock",
                 title=f"Pauschalreise nach {destination}",
                 price=price,
                 url=f"https://example.com/offers/{destination.lower().replace(' ', '-')}",
@@ -681,7 +692,8 @@ def _fallback_mock_offers(config: AgentConfig, reason: str | None = None) -> Lis
                     "nights": 7,
                     "board": "Halbpension",
                     "origin": config.origin or "Beliebig",
-                    "reason": reason or "mock",
+                    "reason": mock_reason,
+                    "mock_reason": mock_reason,
                     "star_rating": mocked_star_ratings[idx % len(mocked_star_ratings)],
                     "recommendation_score": mocked_recommendations[idx % len(mocked_recommendations)],
                 },

--- a/agent_core/workflow.py
+++ b/agent_core/workflow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from .config import AgentConfig
 from .processor import ProcessedOffer, prepare_offers, summarise_offers
@@ -19,6 +19,7 @@ class AgentResult:
     offers: List[ProcessedOffer]
     report: str
     summary: Dict[str, float]
+    warnings: List[str]
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -26,6 +27,8 @@ class AgentResult:
             "summary": self.summary,
             "offers": [offer.to_dict() for offer in self.offers],
             "report": self.report,
+            "warnings": list(self.warnings),
+            "raw_offers": [offer.to_dict() for offer in self.raw_offers],
         }
 
 
@@ -33,7 +36,42 @@ def run_agent_workflow(config: AgentConfig) -> AgentResult:
     """Execute the full data acquisition and reporting pipeline."""
 
     raw_offers = scrape_sources(config)
+    warnings = _collect_mock_warnings(raw_offers)
     offers = prepare_offers(raw_offers, config)
     summary = summarise_offers(offers)
-    report = build_report(config, offers)
-    return AgentResult(config=config, raw_offers=raw_offers, offers=offers, summary=summary, report=report)
+    report = build_report(config, offers, warnings=warnings)
+    return AgentResult(
+        config=config,
+        raw_offers=raw_offers,
+        offers=offers,
+        summary=summary,
+        report=report,
+        warnings=warnings,
+    )
+
+
+def _collect_mock_warnings(raw_offers: List[RawOffer]) -> List[str]:
+    """Inspect raw offers and derive user-facing warnings for mock data."""
+
+    mock_reasons: Set[str] = {
+        str(offer.metadata.get("mock_reason"))
+        for offer in raw_offers
+        if offer.metadata.get("mock_reason")
+    }
+    if not mock_reasons:
+        return []
+
+    readable_reasons = []
+    reason_messages = {
+        "playwright-missing": "Playwright nicht verfügbar",
+        "playwright-empty": "keine Ergebnisse von Playwright erhalten",
+    }
+    for reason in sorted(mock_reasons):
+        readable_reasons.append(reason_messages.get(reason, reason))
+
+    if readable_reasons:
+        details = "; ".join(readable_reasons)
+        message = f"Playwright-Suche fehlgeschlagen, zeige Beispielangebote (Details: {details})."
+    else:
+        message = "Playwright-Suche fehlgeschlagen, zeige Beispielangebote."
+    return [message]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,13 +1,15 @@
 import sys
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agent_core.config import AgentConfig
 from agent_core.processor import prepare_offers, summarise_offers
 from agent_core.reporter import build_report
-from agent_core.scraper import RawOffer
+from agent_core.scraper import RawOffer, _fallback_mock_offers
+from agent_core.workflow import run_agent_workflow
 
 
 class ProcessorPipelineTests(unittest.TestCase):
@@ -119,6 +121,23 @@ class ProcessorPipelineTests(unittest.TestCase):
         report = build_report(config, processed_offers)
         self.assertIn("Keine Angebote mit Preisangabe", report)
         self.assertIn("| NoPrice | Berlin | – |", report)
+
+    def test_mock_offers_trigger_warning_and_metadata(self) -> None:
+        config = AgentConfig(destinations=["Berlin"])
+        fallback_offers = _fallback_mock_offers(config, reason="playwright-empty")
+
+        with patch("agent_core.workflow.scrape_sources", return_value=fallback_offers):
+            result = run_agent_workflow(config)
+
+        expected_warning = "Playwright-Suche fehlgeschlagen, zeige Beispielangebote (Details: keine Ergebnisse von Playwright erhalten)."
+        self.assertIn(f"WARNUNG: {expected_warning}", result.report)
+        self.assertIn(expected_warning, result.warnings)
+
+        payload = result.to_dict()
+        self.assertIn(expected_warning, payload["warnings"])
+        self.assertTrue(payload["raw_offers"])
+        for offer in payload["raw_offers"]:
+            self.assertEqual(offer["metadata"].get("mock_reason"), "playwright-empty")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- mark fallback mock offers with a mock_reason flag and mock provider metadata
- expose warnings and raw offer metadata via AgentResult and surface warnings in reports
- add regression test ensuring mock warnings and metadata propagate through the workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb078f468483318bd617c3f714e5ab